### PR TITLE
Improve handling of Unix commands

### DIFF
--- a/challenges/views.py
+++ b/challenges/views.py
@@ -108,8 +108,6 @@ def index(request):
 @login_required()
 def validation(request):
     if (request.method == "POST"):
-        
-
         json_response = [] 
         allGood = True
         success = False
@@ -117,10 +115,8 @@ def validation(request):
         if (AssignmentDates.objects.all()):
             currentTime = datetime.now().time()
             currentDate = datetime.today().date()
-
             openDate = AssignmentDates.objects.get(description="open")
             closeDate = AssignmentDates.objects.get(description="closed")
-            
 
             if currentDate < openDate.date or currentDate > closeDate.date:
                 allGood = False
@@ -129,13 +125,12 @@ def validation(request):
                 if (currentTime > closeDate.time and currentTime == closeDate.date) or (currentTime < openDate.time and currentTime == openDate.date):
                     allGood = False
 
-
         challenge_id = int(request.POST['challenge_id'])
         challenge = Challenge.objects.get(order=challenge_id)
         customUser = CustomUser.objects.get(user=request.user.id)
 
         # Create the JSON object
-
+        ########################
         if (challenge.flag == request.POST['passcode'].strip()):
             success = True
             data = json.loads(customUser.challenges)
@@ -156,10 +151,7 @@ def validation(request):
                 
                 data[challenge_id]['completed'] = 'true'
                 if not challenge_id + 1 > len(Challenge.objects.all()) - 1:
-
                     data[challenge_id + 1]['hidden'] = 'false'
-
-
 
                 if (customUser.correctInARow % 8) == 2:
                     achievements = json.loads(customUser.achievements)
@@ -225,17 +217,14 @@ def validation(request):
                         classThird.earned = True
                         classThird.save()
 
-
-
                     if (AssignmentDates.objects.all()):
                         currentTime = datetime.now()
                         currentDate = datetime.today().date()
-
                         closeDate = AssignmentDates.objects.get(description="closed")
-                        
                         offset = timedelta(hours=3)
                         newTime = currentTime + offset
                         time = newTime.time()
+
                         if currentDate == closeDate.date and time > closeDate.time:
                             achievements = json.loads(customUser.achievements)
                             achievements.append('Playing With Fire')
@@ -262,18 +251,13 @@ def validation(request):
                         achievements.append('Committed')
                         customUser.achievements = json.dumps(achievements)
 
-
                 customUser.challenges = json.dumps(data)
                 customUser.save()
 
-
-
         else:
             json_response.append({'success': False})
-
             data = json.loads(customUser.challenges)
             incorrectPerChallengeData = json.loads(customUser.incorrectPerChallenge)
-    
 
             if customUser.numTotalIncorrectGuesses > 250:
                 achievements = json.loads(customUser.achievements)
@@ -293,7 +277,6 @@ def validation(request):
                 customUser.incorrectPerChallenge = json.dumps(incorrectPerChallengeData)
                 customUser.save()
 
-
         if not allGood:
             if success:
                 json_response.append({'success': "Assignment is closed"})
@@ -305,28 +288,23 @@ def validation(request):
             if success:
                 json_response.append({'success': True})
 
-
         response = JsonResponse(json_response, safe=False)
         response['Access-Control-Allow-Origin'] = '*'
-
         return response
-
 
 
 @login_required()
 def challengeDetails(request, order):
     challengeID = order
     order = order - 1
-
     challenge = get_object_or_404(Challenge, order=order)
     customUser = CustomUser.objects.get(user=request.user.id)
     data = json.loads(customUser.challenges)
+
     admin = customUser.admin
     adminFlag = ''
-
     if admin:
         adminFlag = Challenge.objects.get(templateValue=12).flag
-
 
     challenge.data = data[order]
     if (challengeID < Challenge.objects.all().count()):
@@ -341,12 +319,12 @@ def challengeDetails(request, order):
 
     return render(request, f'challenges/{challenge.templateValue}.html', {'challenge': challenge, 'admin': admin, 'adminFlag': adminFlag})
 
+
 @login_required()
 def hardChallenges(request):
     hardChallenges = Challenge.objects.filter(difficultyIndicator="Hard")
     customUser = CustomUser.objects.get(user=request.user)
     deleted = customUser.completedAllChallenges
-
     bruteForce = hardChallenges[0].order + 1
     bruteForceComplete = 'false'
     crossSite = hardChallenges[1].order + 1
@@ -385,21 +363,18 @@ def completed(request):
     return render(request, 'challenges/allChallenges.html', {'completedChallenges': completedChallenges})
     #return HttpResponse("Congrats! You have finished this level of difficulty!", request)
 
+
 @login_required()
 def allChallenges(request):
-
     challenges = Challenge.objects.all()
     customUser = CustomUser.objects.get(user=request.user.id)
     data = json.loads(customUser.challenges)
     completedChallenges = []
 
-
     for count, challenge in enumerate(challenges):
         challenge.completed = data[count]['completed']
         if data[count]['completed'] == 'true':
             completedChallenges.append(challenge)
-
-
 
     return render(request, 'challenges/allChallenges.html', {'completedChallenges': completedChallenges})
 
@@ -415,11 +390,10 @@ def deleteServer(request):
             data.append('Rick Rolled')
             customUser.achievements = json.dumps(data)
             customUser.save()
-
         return HttpResponseRedirect(reverse('homepage:index'));
+
     else:
         return HttpResponseRedirect(reverse('homepage:index'));
-
 
 
 @login_required()
@@ -429,8 +403,6 @@ def passwordSecurity(request):
 @login_required()
 def security(request):
     challenge = Challenge.objects.get(order=6)
-
-
     if not request.GET:
         return HttpResponse("not authorized")
     elif request.GET['username'] and request.GET['password']:
@@ -438,40 +410,36 @@ def security(request):
     else:
         return HttpResponse("username must not be NULL and password must not be NULL")
 
+
 @login_required()
 def securityValidation(request):
     challenge = Challenge.objects.get(templateValue=7)
-    
-
     if not request.GET:
         return HttpResponse("Not Authorized")
-
     elif request.GET['password'] == "":
-        return HttpResponse("bash: "": command not found")
+        return HttpResponse('<pre>bash: "": command not found</pre>')
     elif request.GET['password'] == "ls":
-        return HttpResponse("somefile.txt\nsomeotherfile.txt\ncleverlynamedfile.txt")
+        return HttpResponse("<pre>somefile.txt<br/>someotherfile.txt<br/>cleverlynamedfile.txt</pre>")
     elif request.GET['password'] == "ls -a":
-        return HttpResponse("somefile.txt\nsomeotherfile.txt\ncleverlynamedfile.txt .env")
+        return HttpResponse("<pre>somefile.txt<br/>someotherfile.txt<br/>cleverlynamedfile.txt<br/>.env</pre>")
     elif request.GET['password'] == "cat .env":
-        return HttpResponse(challenge.flag)
+        return HttpResponse(f"<pre>{challenge.flag}</pre>")
     elif request.GET['password'] == "cat somefile.txt":
-        return HttpResponse("Contents of somefile.txt")
-    elif request.GET['password'] == "cat somefile.txt":
-        return HttpResponse("Contents of somefile.txt")
+        return HttpResponse("<pre>These are the contents of somefile.txt</pre>")
     elif request.GET['password'] == "cat someotherfile.txt":
-        return HttpResponse("Contents of someotherfile.txt")
+        return HttpResponse("<pre>This is what is inside of someotherfile.txt<br/>I know it isn't much to look at.<br/>Look elsewhere for what you seek.</pre>")
     elif request.GET['password'] == "cat cleverlynamedfile.txt":
-        return HttpResponse("Contents of cleverlynamedfile.txt")
+        return HttpResponse("<pre>The contents of cleverlynamedfile.txt don't live up to the hype, do they?</pre>")
     elif request.GET['password'] == "pwd":
-        return HttpResponse("../security/dbvalidation")
+        return HttpResponse("<pre>../security/dbvalidation</pre>")
     elif request.GET['password'] == "cd":
-        return HttpResponse("This command has been scrubbed and we know what you are trying to do!")
+        return HttpResponse("<pre>bash: cd: Permission denied</pre>")
     elif request.GET['password'].startswith("cat"):
-        return HttpResponse("This file doesn't exist")
+        return HttpResponse("<pre>cat: invalid filename</pre>")
     elif request.GET['password'].startswith("cp") or request.GET['password'].startswith("mv") or request.GET['password'].startswith("touch") or  request.GET['password'].startswith("rm") or request.GET['password'].startswith("locate") or  request.GET['password'].startswith("grep"):
-        return HttpResponse("This command has been scrubbed and we know what you are trying to do!")
+        return HttpResponse("<pre>bash: Permission denied</pre>")
     else:
-        return HttpResponse(f"bash: {request.GET['password']}: command not found")
+        return HttpResponse(f"<pre>bash: {request.GET['password']}: command not found</pre>")
 
 
 # TODO: Add the cookie into the database, then I can just serve this actual file when they cat views.py instead
@@ -481,43 +449,30 @@ def securityValidation(request):
 def secure(request):
     # Just in case I forget the password... Its 1a2s3d4f5g6h7j8k9l
     if not request.GET:
-        return HttpResponse("Not Authorized")
+        return HttpResponse("<pre>Not Authorized</pre>")
     elif request.GET['password'] == "":
-        return HttpResponse("Invalid Command") 
-    elif request.GET['password'] == "ls":
-        return HttpResponse("views.py\n")
-    elif request.GET['password'] == "ls -a":
-        return HttpResponse("views.py\n")
+        return HttpResponse("<pre>Invalid Command</pre>") 
+    elif request.GET['password'] == "ls" or request.GET['password'] == "ls -a":
+        return HttpResponse("<pre>views.py</pre>")
     elif request.GET['password'] == "cat views.py":
-        return HttpResponse(leak, content_type='text/plain')
-    elif request.GET['password'] == "cat somefile.txt":
-        return HttpResponse("Contents of somefile.txt")
-    elif request.GET['password'] == "cat somefile.txt":
-        return HttpResponse("Contents of somefile.txt")
-    elif request.GET['password'] == "cat someotherfile.txt":
-        return HttpResponse("Contents of someotherfile.txt")
-    elif request.GET['password'] == "cat cleverlynamedfile.txt":
-        return HttpResponse("Contents of cleverlynamedfile.txt")
+        return HttpResponse(LEAK, content_type='text/plain')
     elif request.GET['password'] == "pwd":
         return HttpResponse("../security/validation")
     elif request.GET['password'] == "cd":
-        return HttpResponse("This command has been scrubbed and we know what you are trying to do!")
+        return HttpResponse("<pre>bash: cd: Permission denied</pre>")
     elif request.GET['password'].startswith("cat"):
-        return HttpResponse("This file doesn't exist")
+        return HttpResponse("<pre>cat: invalid filename</pre>")
     elif request.GET['password'].startswith("cp") or request.GET['password'].startswith("mv") or request.GET['password'].startswith("touch") or  request.GET['password'].startswith("rm") or  request.GET['password'].startswith("locate") or request.GET['password'].startswith("locate") or  request.GET['password'].startswith("grep"):
-        return HttpResponse("This command has been scrubbed and we know what you are trying to do!")
+        return HttpResponse("<pre>bash: Permission denied</pre>")
     else:
-        return HttpResponse(f"bash: {request.GET['password']}: command not found")
+        return HttpResponse(f"<pre>bash: {request.GET['password']}: command not found</pre>")
 
 @login_required()
 def anotherRequest(request):
-
     try:
-
         if (request.headers['allowed']):
             flag = Challenge.objects.get(templateValue=3).flag
             data = [{'flag': flag}]
-
             return JsonResponse(data, safe=False)
     except KeyError:
         return JsonResponse({"Yeah No": "Good try though :)"}, safe=False)
@@ -536,9 +491,7 @@ def cookieValidation(request):
 def hardAdminLogin(request):
     if request.POST['username'] == 'Monkey@monkey.com' and request.POST['password'] == 'yamaha':
         challenge = Challenge.objects.get(templateValue=11)
-        
         return HttpResponse(challenge.flag)
-
     else:
         return HttpResponseForbidden("""
 
@@ -547,20 +500,12 @@ def hardAdminLogin(request):
 
         """)
     
-
-
-
-
 
 @login_required()
 def adminLogin(request):
     if request.POST['username'] == 'ShadyVelociraptor@gmail.com' and request.POST['password'] == 'turtle':
-    
-        
         challenge = Challenge.objects.get(templateValue=10)
-        
         return HttpResponse(challenge.flag)
-
     else:
         return HttpResponseForbidden("""
 
@@ -568,10 +513,9 @@ def adminLogin(request):
             <h5 style="align:center; text-align: center"> Leave this page or suffer the consequences </h5>
 
         """)
-    
 
 
-leak = """
+LEAK = """
 from django.shortcuts import render, get_object_or_404
 from .models import Challenge, Hint
 from loginSignup.models import CustomUser
@@ -590,8 +534,6 @@ def index(request):
         challenge.hidden = data[count]['hidden']
         challenge.completed = data[count]['completed']
         challenge.data = data[count]
-
-
     return render(request, 'challenges/index.html', {'challenges': challenges})
 
 
@@ -617,16 +559,13 @@ def validation(request):
                 data[challenge_id + 1]['hidden'] = 'false'
                 customUser.challenges = json.dumps(data)
                 customUser.save()
-
-
-
         else:
             json_response.append({'success': False})
 
         response = JsonResponse(json_response, safe=False)
         response['Access-Control-Allow-Origin'] = '*'
-
         return response
+
 
 # TODO: Get the information for which challenge to send them to from a database instead of static as I am currently doing. This allows us to easier change the order of the levels and it will correctly point to the html page that it should. Essentially, it will be a dictionary mapping the challenge to a html page (instead of currently the order mapping it strictly to an html page, which makes it if the order changes, then it doesn't update correctly to the new html page
 
@@ -647,15 +586,15 @@ def challengeDetails(request, challenge_id):
 
     return render(request, f'challenges/challenge{challenge_id - 1}.html', {'challenge': challenge})
 
+
 @login_required()
 def passwordSecurity(request):
     return HttpResponse(200);
 
+
 @login_required()
 def security(request):
     challenge = Challenge.objects.get(order=6)
-
-
     if not request.GET:
         return HttpResponse("not authorized")
     elif request.GET['username'] and request.GET['password']:
@@ -663,14 +602,12 @@ def security(request):
     else:
         return HttpResponse("username must not be NULL and password must not be NULL")
 
+
 @login_required()
 def securityValidation(request):
     challenge = Challenge.objects.get(order=7)
-    
-
     if not request.GET:
         return HttpResponse("Not Authorized")
-
     elif request.GET['password'] == "":
         return HttpResponse("bash: "": command not found")
     elif request.GET['password'] == "ls":


### PR DESCRIPTION
Hey Ryan,

I've made some QoL improvements to the views that handle the Unix OS commands.

*    Disable `shell=True` from calls to `subprocess.run()` - leaving that on opens the possibility of students adding an extra, un-sanitized command following a `;` or `&` or `&&`
*    Pass the `cwd` keyword argument to `subprocess.run()` to put it into the **whiteBoxHacking** directory; this is more elegant than trying to prepend that string to all arguments
*    Streamline calling of `subprocess.run()` in all cases where we want to do that
*    Add more "fake" commands to improve the fidelity of the simulation
*    Wrap all output in `<pre>` tags to improve readability

I was unable to test this in-situ because I don't remember how to re-start the server through Docker.  Let's test this together soon.  I want to make sure that this feels realistic for the smart kids, and also keeps them from breaking the server!